### PR TITLE
[Key-Value-Service] Add implementation for persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ $ make
 $ ./key_value_service
 ```
 
+Persistent storage mode can be activated by setting store flag. Once activated, key value
+server will load commands from log file and execute sequentially. Users' input will also be saved into designated log file.
+```sh
+$ ./key_value_service --store "[LOG_FILE]"
+```
+
 ### 3.2 Compile warbler service
 Create another terminal window. Run following commands.
 ```sh

--- a/command_line_tool/command_line_helper.cc
+++ b/command_line_tool/command_line_helper.cc
@@ -28,11 +28,12 @@ void PrintUser(const std::string& username,
   for (std::string following_user : following) {
     std::cout << following_user << " ";
   }
-  
+  std::cout << std::endl;
   std::cout << "User : " << username << " is followed by :";
   for (std::string follower : followers) {
     std::cout << follower << " ";
   }
+  std::cout << std::endl;
   std::cout << "=====================user=====================" << std::endl;
 }
 

--- a/key_value_store/key_value_service.cc
+++ b/key_value_store/key_value_service.cc
@@ -88,31 +88,30 @@ Status KeyValueStoreImpl::remove(ServerContext* context,
   return Status(StatusCode::NOT_FOUND, "Failed to delete the key.");
 }
 
-// When instantiating a KeyValueStore class, load data from persistent_db_
+// When instantiating a KeyValueStore class, load data from persistent_file_
 // if the file exists.
 void KeyValueStoreImpl::PersistentLoad() {
-  if (persistent_db_.length() == 0) {
+  if (persistent_file_.length() == 0) {
     persistent_mode_ = false;
     return;
   }
   
   persistent_mode_ = true;
   std::ifstream in_file;
-  in_file.open(persistent_db_);
+  in_file.open(persistent_file_);
   // If file doesn't exist before, create it.
   if (!in_file.is_open()) {
-    std::cout << "Create new file " << persistent_db_ << " for persistent store..." << std::endl;
+    std::cout << "Create new file " << persistent_file_ << " for persistent store..." << std::endl;
     std::ofstream out_file;
-    out_file.open(persistent_db_);
+    out_file.open(persistent_file_);
     out_file.close();
     std::cout << "Successfully created." << std::endl;
     return;
   }
-  /* 
-    Read data from persistent_db_. Key-Value pairs in `put` request are separated into four
-    parts. 1. # of chars for key; 2. Key; 3. # of chars for value; 4. Value;
-    For `remove` request, Only key is stored. Only first two parts are stored.
-  */
+   
+  //  Read data from persistent_file_. Key-Value pairs in `put` request are separated into four
+  //  parts. 1. # of chars for key; 2. Key; 3. # of chars for value; 4. Value;
+  //  For `remove` request, Only key is stored. Only first two parts are stored.
   std::string request;
   while (getline(in_file, request)) {
     std::string key_len, value_len, key, value;
@@ -137,9 +136,9 @@ void KeyValueStoreImpl::PersistentLoad() {
 }
 
 // If persistent store mode is set, Put and Remove request will be saved into
-// persistent_db_ file
+// persistent_file_
 void KeyValueStoreImpl::PersistentStore(std::string request, std::string key, std::string value) {
-  std::ofstream out_file(persistent_db_, std::ios_base::app | std::ios_base::out);
+  std::ofstream out_file(persistent_file_, std::ios_base::app | std::ios_base::out);
   out_file << request << "\n";
   out_file << key.length() << "\n";
   out_file << key << "\n";

--- a/key_value_store/key_value_service.cc
+++ b/key_value_store/key_value_service.cc
@@ -48,7 +48,7 @@ Status KeyValueStoreImpl::put(ServerContext* context,
   bool put_result = storage_.Put(request->key(), request->value());
   // If persistent mode is activated, save key and value into file.
   if (persistent_mode_) {
-    Persistent_store("put", request->key(), request->value());
+    PersistentStore("put", request->key(), request->value());
   }
   return Status::OK;
 }
@@ -81,7 +81,7 @@ Status KeyValueStoreImpl::remove(ServerContext* context,
   if (storage_.DeleteKey(request->key())) {
     // If persistent mode is activated, append remove request into file.
     if (persistent_mode_) {
-      Persistent_store("remove", request->key(), "");
+      PersistentStore("remove", request->key(), "");
     }
     return Status::OK;
   }
@@ -90,7 +90,7 @@ Status KeyValueStoreImpl::remove(ServerContext* context,
 
 // When instantiating a KeyValueStore class, load data from persistent_db_
 // if the file exists.
-void KeyValueStoreImpl::Persistent_load() {
+void KeyValueStoreImpl::PersistentLoad() {
   if (persistent_db_.length() == 0) {
     persistent_mode_ = false;
     return;
@@ -138,7 +138,7 @@ void KeyValueStoreImpl::Persistent_load() {
 
 // If persistent store mode is set, Put and Remove request will be saved into
 // persistent_db_ file
-void KeyValueStoreImpl::Persistent_store(std::string request, std::string key, std::string value) {
+void KeyValueStoreImpl::PersistentStore(std::string request, std::string key, std::string value) {
   std::ofstream out_file(persistent_db_, std::ios_base::app | std::ios_base::out);
   out_file << request << "\n";
   out_file << key.length() << "\n";

--- a/key_value_store/key_value_service.cc
+++ b/key_value_store/key_value_service.cc
@@ -24,11 +24,32 @@ using std::string;
 using std::vector;
 using kvstorage::Storage;
 
+// When store flag is defined, class will load information from file.
+// Put and Remove request will be saved into file. The operation is 
+// similar to AOF in redis.
+DEFINE_string(store, "", "Use persistent store mode.");
 namespace kvstore {
+
+// Method used to read number character from in_file.
+std::string ReadNCharacter(std::ifstream& in_file, int num_character) {
+  std::string result = "";
+  char ch;
+  while (num_character > 0) {
+    in_file.get(ch);
+    result += ch;
+    num_character --;
+  }
+  in_file.get(ch);
+  return result;
+}
 // Put element into key value backend storage. If put failed, return StatusCode::UNKNOWN
 Status KeyValueStoreImpl::put(ServerContext* context, 
                                const PutRequest* request, PutReply* reply) {
   bool put_result = storage_.Put(request->key(), request->value());
+  // If persistent mode is activated, save key and value into file.
+  if (persistent_mode_) {
+    Persistent_store("put", request->key(), request->value());
+  }
   return Status::OK;
 }
 
@@ -58,18 +79,85 @@ Status KeyValueStoreImpl::get(ServerContext* context,
 Status KeyValueStoreImpl::remove(ServerContext* context, 
                                      const RemoveRequest* request, RemoveReply* reply) {
   if (storage_.DeleteKey(request->key())) {
+    // If persistent mode is activated, append remove request into file.
+    if (persistent_mode_) {
+      Persistent_store("remove", request->key(), "");
+    }
     return Status::OK;
   }
   return Status(StatusCode::NOT_FOUND, "Failed to delete the key.");
+}
+
+// When instantiating a KeyValueStore class, load data from persistent_db_
+// if the file exists.
+void KeyValueStoreImpl::Persistent_load() {
+  if (persistent_db_.length() == 0) {
+    persistent_mode_ = false;
+    return;
+  }
+  
+  persistent_mode_ = true;
+  std::ifstream in_file;
+  in_file.open(persistent_db_);
+  // If file doesn't exist before, create it.
+  if (!in_file.is_open()) {
+    std::cout << "Create new file " << persistent_db_ << " for persistent store..." << std::endl;
+    std::ofstream out_file;
+    out_file.open(persistent_db_);
+    out_file.close();
+    std::cout << "Successfully created." << std::endl;
+    return;
+  }
+  /* 
+    Read data from persistent_db_. Key-Value pairs in `put` request are separated into four
+    parts. 1. # of chars for key; 2. Key; 3. # of chars for value; 4. Value;
+    For `remove` request, Only key is stored. Only first two parts are stored.
+  */
+  std::string request;
+  while (getline(in_file, request)) {
+    std::string key_len, value_len, key, value;
+    if (request.compare("put") == 0) {
+      getline(in_file, key_len);
+      key = ReadNCharacter(in_file, std::stoi(key_len));
+      getline(in_file, value_len);
+      value = ReadNCharacter(in_file, std::stoi(value_len));
+      storage_.Put(key, value);
+    } else if (request.compare("remove") == 0) {
+      getline(in_file, key_len);
+      key = ReadNCharacter(in_file, std::stoi(key_len));
+      storage_.DeleteKey(key);
+    } else {
+      // meet eof character. just break
+      break;
+    }
+  }
+
+  in_file.close();
+  return;
+}
+
+// If persistent store mode is set, Put and Remove request will be saved into
+// persistent_db_ file
+void KeyValueStoreImpl::Persistent_store(std::string request, std::string key, std::string value) {
+  std::ofstream out_file(persistent_db_, std::ios_base::app | std::ios_base::out);
+  out_file << request << "\n";
+  out_file << key.length() << "\n";
+  out_file << key << "\n";
+  if (request.compare("put") == 0) { 
+    out_file << value.length() << "\n";
+    out_file << value << "\n";
+  }
+  out_file.close();
 }
 
 } // End of namespace kvstore.
 
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, true);
   string key_value_server_address("0.0.0.0:50001");
   ServerBuilder serverbuilder;
-  kvstore::KeyValueStoreImpl service_impl;
+  kvstore::KeyValueStoreImpl service_impl(FLAGS_store);
   serverbuilder.AddListeningPort(key_value_server_address, 
                             grpc::InsecureServerCredentials());
   serverbuilder.RegisterService(&service_impl);

--- a/key_value_store/key_value_service.h
+++ b/key_value_store/key_value_service.h
@@ -1,6 +1,11 @@
 #ifndef KEY_VALUE_SERVICE_H
 #define KEY_VALUE_SERVICE_H
+#include <string>
+#include <iostream>
+#include <fstream>
+
 #include <grpcpp/grpcpp.h>
+#include <gflags/gflags.h>
 
 #include "key_value_store.pb.h"
 #include "key_value_store.grpc.pb.h"
@@ -26,6 +31,7 @@ namespace kvstore {
   implements put, get and remove rpc service defined in the proto file.
 */
 class KeyValueStoreImpl final : public KeyValueStore::Service {
+public:
   // Put element into key value backend storage. If put failed, return StatusCode::UNKNOWN
   Status put(ServerContext* context, 
   	          const PutRequest* request, PutReply* reply) override;
@@ -35,8 +41,23 @@ class KeyValueStoreImpl final : public KeyValueStore::Service {
   // Delete a given key from backend storage. If key doesn't exist, return StatuCode::NOT_FOUND.
   Status remove(ServerContext* context, 
   	                const RemoveRequest* request, RemoveReply* reply) override;
+  // Constructor for KeyValueStoreImpl class.
+  KeyValueStoreImpl(std::string file) : KeyValueStore::Service(), persistent_db_(file){
+    Persistent_load();
+  }
+
  private:
   Storage storage_;
+  std::string persistent_db_;
+  bool persistent_mode_;
+
+  // When instantiating a KeyValueStore class, load data from persistent_db_
+  // if the file exists.
+  void Persistent_load();
+
+  // If persistent store mode is set, Put and Remove request will be saved into
+  // persistent_db_ file
+  void Persistent_store(std::string request, std::string key, std::string value);
 };
 }// End of namespace kvstore
 

--- a/key_value_store/key_value_service.h
+++ b/key_value_store/key_value_service.h
@@ -42,21 +42,21 @@ public:
   Status remove(ServerContext* context, 
   	                const RemoveRequest* request, RemoveReply* reply) override;
   // Constructor for KeyValueStoreImpl class.
-  KeyValueStoreImpl(std::string file) : KeyValueStore::Service(), persistent_db_(file){
+  KeyValueStoreImpl(std::string file) : KeyValueStore::Service(), persistent_file_(file){
     PersistentLoad();
   }
 
  private:
   Storage storage_;
-  std::string persistent_db_;
+  std::string persistent_file_;
   bool persistent_mode_;
 
-  // When instantiating a KeyValueStore class, load data from persistent_db_
+  // When instantiating a KeyValueStore class, load data from persistent_file_
   // if the file exists.
   void PersistentLoad();
 
   // If persistent store mode is set, Put and Remove request will be saved into
-  // persistent_db_ file
+  // persistent_file_
   void PersistentStore(std::string request, std::string key, std::string value);
 };
 }// End of namespace kvstore

--- a/key_value_store/key_value_service.h
+++ b/key_value_store/key_value_service.h
@@ -43,7 +43,7 @@ public:
   	                const RemoveRequest* request, RemoveReply* reply) override;
   // Constructor for KeyValueStoreImpl class.
   KeyValueStoreImpl(std::string file) : KeyValueStore::Service(), persistent_db_(file){
-    Persistent_load();
+    PersistentLoad();
   }
 
  private:
@@ -53,11 +53,11 @@ public:
 
   // When instantiating a KeyValueStore class, load data from persistent_db_
   // if the file exists.
-  void Persistent_load();
+  void PersistentLoad();
 
   // If persistent store mode is set, Put and Remove request will be saved into
   // persistent_db_ file
-  void Persistent_store(std::string request, std::string key, std::string value);
+  void PersistentStore(std::string request, std::string key, std::string value);
 };
 }// End of namespace kvstore
 


### PR DESCRIPTION
In this pull request, persistent storage mode is implemented in key value server. Once activated, the server will save users' requests into log file. While restarting the server with designated log file, the commands will be re-executed to restore previous state of server.
```sh
$ ./key_value_service --store "persistent_db.txt"
```
The log file has similar structure with redis AOF mode. An example is shown below for illustration: 

After put->remove->put operations, persistent_db.txt file will store following information.

**In persistent_db.txt:**

put
4
key1
6
value1
remove
4
key1
put
9
key_user1
11
value_user1